### PR TITLE
Fix #9: RDoc::Markup::Paragraph objects have no 'each' method.

### DIFF
--- a/lib/puppet-doc-lint/parser.rb
+++ b/lib/puppet-doc-lint/parser.rb
@@ -64,8 +64,8 @@ class PuppetDocLint
 
         author_docs.each do | doc_chunk |
           unless doc_chunk[1].class == RDoc::Markup::BlankLine || doc_chunk[1].class == RDoc::Markup::Heading
-            doc_chunk[1].items.each do |chunk|
-              authors << chunk.parts.first.parts
+            doc_chunk[1].parts.each do |chunk|
+              authors << chunk
             end
           end
         end

--- a/spec/manifests/parameters_rdoc.pp
+++ b/spec/manifests/parameters_rdoc.pp
@@ -10,6 +10,11 @@
 #
 # [*param_one*]
 #    Param1 documentation text
+#
+# == Authors
+#
+# Some Author <some@author.com>
+#
 class parameters_rdoc (
   $param_one = true,
   $param_two = '',


### PR DESCRIPTION
Instead, they have a 'parts' method that returns
an enumerator. This patch uses that enumerator to walk
through the authors and append them to the authors
hash.
