### PR TITLE
Allow for any recent version of puppet and facter

### DIFF
--- a/lib/puppet-doc-lint/parser.rb
+++ b/lib/puppet-doc-lint/parser.rb
@@ -3,7 +3,7 @@ class PuppetDocLint
 
     def initialize(file)
       # Read file and return parsed object
-      pparser         = Puppet::Parser::Parser.new('production')
+      pparser = Puppet::Parser::Parser.new(Puppet::Node::Environment.new('production'))
       if File.exists?(file)
         @file = File.expand_path(file)
         pparser.import(@file)

--- a/puppet-doc-lint.gemspec
+++ b/puppet-doc-lint.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 2.14.1'
   gem.add_development_dependency 'rake', '~> 10.1.1'
   gem.add_runtime_dependency 'rdoc', '>=3.12', '<4.0'
-  gem.add_runtime_dependency 'facter', '~> 1.6'
-  gem.add_runtime_dependency 'puppet', '~> 3.4.2'
+  gem.add_runtime_dependency 'facter'
+  gem.add_runtime_dependency 'puppet'
   gem.add_runtime_dependency 'virtus', '~> 1.0.1'
 
 


### PR DESCRIPTION
This allows puppet-doc-lint to work with any recent puppet version.
Also when using puppet 3.5 or higher solves #4 

Fixes #4 #11 
